### PR TITLE
Migrate to null safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ pubspec.lock
 build/
 .idea/
 android/bin/
+
+example/.flutter-plugins-dependencies
+
+example/ios/Flutter/flutter_export_environment.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0
+* Migrate to null-safety
+
 ## 2.3.4
 * Added support for setting bottom padding
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,7 +20,7 @@ class SampleApp extends StatelessWidget {
           title: const Text('Intercom example app'),
         ),
         body: Center(
-          child: FlatButton(
+          child: TextButton(
             onPressed: () {
               Intercom.displayMessenger();
             },

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: intercom_example
 description: Demonstrates how to use the intercom_flutter plugin.
+publish_to: none
 
 version: 1.0.0+1
 
@@ -14,4 +15,4 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=2.10.0 <3.0.0'
+  sdk: '>=2.12.0-133.7.beta <3.0.0'

--- a/lib/intercom_flutter.dart
+++ b/lib/intercom_flutter.dart
@@ -12,12 +12,12 @@ class Intercom {
   static const EventChannel _unreadChannel =
       const EventChannel('maido.io/intercom/unread');
 
-  static Future<dynamic> initialize(
+  static Future<void> initialize(
     String appId, {
-    String androidApiKey,
-    String iosApiKey,
-  }) {
-    return _channel.invokeMethod('initialize', {
+    String? androidApiKey,
+    String? iosApiKey,
+  }) async {
+    await _channel.invokeMethod('initialize', {
       'appId': appId,
       'androidApiKey': androidApiKey,
       'iosApiKey': iosApiKey,
@@ -27,20 +27,20 @@ class Intercom {
   static Stream<dynamic> getUnreadStream() {
     return _unreadChannel.receiveBroadcastStream();
   }
-  
+
   /// This method allows you to set a fixed bottom padding for in app messages and the launcher.
   ///
   /// It is useful if your app has a tab bar or similar UI at the bottom of your window.
   /// [padding] is the size of the bottom padding in points.
-  static Future<dynamic> setBottomPadding(int padding) {
-    return _channel.invokeMethod('setBottomPadding', {'bottomPadding': padding});
+  static Future<void> setBottomPadding(int padding) async {
+    await _channel.invokeMethod('setBottomPadding', {'bottomPadding': padding});
   }
 
-  static Future<dynamic> setUserHash(String userHash) {
-    return _channel.invokeMethod('setUserHash', {'userHash': userHash});
+  static Future<void> setUserHash(String userHash) async {
+    await _channel.invokeMethod('setUserHash', {'userHash': userHash});
   }
 
-  static Future<dynamic> registerIdentifiedUser({String userId, String email}) {
+  static Future<void> registerIdentifiedUser({String? userId, String? email}) {
     if (userId?.isNotEmpty ?? false) {
       if (email?.isNotEmpty ?? false) {
         throw ArgumentError(
@@ -59,21 +59,21 @@ class Intercom {
     }
   }
 
-  static Future<dynamic> registerUnidentifiedUser() {
-    return _channel.invokeMethod('registerUnidentifiedUser');
+  static Future<void> registerUnidentifiedUser() async {
+    await _channel.invokeMethod('registerUnidentifiedUser');
   }
 
-  static Future<dynamic> updateUser({
-    String email,
-    String name,
-    String phone,
-    String company,
-    String companyId,
-    String userId,
-    int signedUpAt,
-    Map<String, dynamic> customAttributes,
-  }) {
-    return _channel.invokeMethod('updateUser', <String, dynamic>{
+  static Future<void> updateUser({
+    String? email,
+    String? name,
+    String? phone,
+    String? company,
+    String? companyId,
+    String? userId,
+    int? signedUpAt,
+    Map<String, dynamic>? customAttributes,
+  }) async {
+    await _channel.invokeMethod('updateUser', <String, dynamic>{
       'email': email,
       'name': name,
       'phone': phone,
@@ -85,71 +85,72 @@ class Intercom {
     });
   }
 
-  static Future<dynamic> logout() {
-    return _channel.invokeMethod('logout');
+  static Future<void> logout() async {
+    await _channel.invokeMethod('logout');
   }
 
-  static Future<dynamic> setLauncherVisibility(IntercomVisibility visibility) {
+  static Future<void> setLauncherVisibility(
+      IntercomVisibility visibility) async {
     String visibilityString =
         visibility == IntercomVisibility.visible ? 'VISIBLE' : 'GONE';
-    return _channel.invokeMethod('setLauncherVisibility', {
+    await _channel.invokeMethod('setLauncherVisibility', {
       'visibility': visibilityString,
     });
   }
 
-  static Future<int> unreadConversationCount() {
-    return _channel.invokeMethod('unreadConversationCount');
+  static Future<int> unreadConversationCount() async {
+    final result = await _channel.invokeMethod<int>('unreadConversationCount');
+    return result ?? 0;
   }
 
-  static Future<dynamic> setInAppMessagesVisibility(
-      IntercomVisibility visibility) {
+  static Future<void> setInAppMessagesVisibility(
+      IntercomVisibility visibility) async {
     String visibilityString =
         visibility == IntercomVisibility.visible ? 'VISIBLE' : 'GONE';
-    return _channel.invokeMethod('setInAppMessagesVisibility', {
+    await _channel.invokeMethod('setInAppMessagesVisibility', {
       'visibility': visibilityString,
     });
   }
 
-  static Future<dynamic> displayMessenger() {
-    return _channel.invokeMethod('displayMessenger');
+  static Future<void> displayMessenger() async {
+    await _channel.invokeMethod('displayMessenger');
   }
 
-  static Future<dynamic> hideMessenger() {
-    return _channel.invokeMethod('hideMessenger');
+  static Future<void> hideMessenger() async {
+    await _channel.invokeMethod('hideMessenger');
   }
 
-  static Future<dynamic> displayHelpCenter() {
-    return _channel.invokeMethod('displayHelpCenter');
+  static Future<void> displayHelpCenter() async {
+    await _channel.invokeMethod('displayHelpCenter');
   }
 
-  static Future<dynamic> logEvent(String name,
-      [Map<String, dynamic> metaData]) {
-    return _channel
+  static Future<void> logEvent(String name,
+      [Map<String, dynamic>? metaData]) async {
+    await _channel
         .invokeMethod('logEvent', {'name': name, 'metaData': metaData});
   }
 
-  static Future<dynamic> sendTokenToIntercom(String token) {
-    assert(token != null && token.isNotEmpty);
+  static Future<void> sendTokenToIntercom(String token) async {
+    assert(token.isNotEmpty);
     print("Start sending token to Intercom");
-    return _channel.invokeMethod('sendTokenToIntercom', {'token': token});
+    await _channel.invokeMethod('sendTokenToIntercom', {'token': token});
   }
 
-  static Future<dynamic> handlePushMessage() {
-    return _channel.invokeMethod('handlePushMessage');
+  static Future<void> handlePushMessage() async {
+    await _channel.invokeMethod('handlePushMessage');
   }
 
-  static Future<dynamic> displayMessageComposer(String message) {
-    return _channel
-        .invokeMethod('displayMessageComposer', {'message': message});
+  static Future<void> displayMessageComposer(String message) async {
+    await _channel.invokeMethod('displayMessageComposer', {'message': message});
   }
 
   static Future<bool> isIntercomPush(Map<String, dynamic> message) async {
     if (!message.values.every((item) => item is String)) {
       return false;
     }
-
-    return await _channel
+    final result = await _channel
         .invokeMethod<bool>('isIntercomPush', {'message': message});
+    return result ?? false;
   }
 
   static Future<void> handlePush(Map<String, dynamic> message) async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: intercom_flutter
 description: Flutter plugin for Intercom integration. Provides in-app messaging
   and help-center Intercom services
-version: 2.3.4
+version: 3.0.0
 homepage: https://github.com/v3rm0n/intercom_flutter
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  collection: ^1.15.0-nullsafety.4
 
 flutter:
   plugin:
@@ -22,5 +23,5 @@ flutter:
         pluginClass: IntercomFlutterPlugin
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0-133.7.beta <3.0.0'
   flutter: ">=1.12.13+hotfix.7 <2.0.0"

--- a/test/intercom_flutter_test.dart
+++ b/test/intercom_flutter_test.dart
@@ -205,10 +205,10 @@ void main() {
 
     setUp(() {
       channel.setMockMethodCallHandler((MethodCall methodCall) async {
-        ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        ServicesBinding.instance!.defaultBinaryMessenger.handlePlatformMessage(
           channelName,
           const StandardMethodCodec().encodeSuccessEnvelope(value),
-          (ByteData data) {},
+          (ByteData? data) {},
         );
       });
     });

--- a/test/test_method_channel.dart
+++ b/test/test_method_channel.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,7 +12,7 @@ void setUpTestMethodChannel(String methodChannel) {
   channel.setMockMethodCallHandler((methodCall) async {
     _log.add(methodCall);
     final matchingStubbing = _responses.keys
-        .firstWhere((s) => s.matches(methodCall), orElse: () => null);
+        .firstWhereOrNull((s) => s.matches(methodCall));
     if (matchingStubbing != null) {
       return _responses[matchingStubbing];
     }
@@ -34,8 +35,8 @@ class MethodCallStubbing {
   }
 
   bool matches(MethodCall methodCall) {
-    return nameMatcher.matches(methodCall.method, null) &&
-        argMatcher.matches(methodCall.arguments, null);
+    return nameMatcher.matches(methodCall.method, {}) &&
+        argMatcher.matches(methodCall.arguments, {});
   }
 }
 
@@ -43,7 +44,7 @@ MethodCallStubbing whenMethodCall(Matcher nameMatcher, Matcher argMatcher) {
   return MethodCallStubbing(nameMatcher, argMatcher);
 }
 
-void expectMethodCall(String name, {Map<String, Object> arguments}) {
+void expectMethodCall(String name, {Map<String, Object?>? arguments}) {
   expect(
     _log[_expectCounter++],
     isMethodCall(name, arguments: arguments),


### PR DESCRIPTION
Implements new Dart's null-safety feature for `intercom_flutter`.

Fixes #122.

Can be published to stable already (will be marked as Preview release).
See this article: https://medium.com/dartlang/preparing-the-dart-and-flutter-ecosystem-for-null-safety-e550ce72c010